### PR TITLE
Increase git http.postBuffer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian as tdlib-builder
 RUN apt update && apt install git make cmake g++ libssl-dev zlib1g-dev gperf -y
+RUN git config --global http.postBuffer 1048576000
 RUN git clone https://github.com/tdlib/td
 WORKDIR /td/build
 RUN git checkout $TDLIB_COMMIT_HASH


### PR DESCRIPTION
Increase postBuffer so that RPC errors do not happen:

```
0.213 Cloning into 'td'...
64.99 error: RPC failed; curl 92 HTTP/2 stream 5 was not closed cleanly: CANCEL (err 8) 
64.99 error: 1199 bytes of body are still expected 
64.99 fetch-pack: unexpected disconnect while reading sideband packet 64.99 fatal: early EOF
64.99 fatal: fetch-pack: invalid index-pack output
```